### PR TITLE
Remove unnecessary SerializeField attribute

### DIFF
--- a/Editor/AnimPlayerGUI.cs
+++ b/Editor/AnimPlayerGUI.cs
@@ -204,7 +204,6 @@ namespace Reallusion.Import
         private static string paramDirection = "param_direction";
         [SerializeField]
         private static AnimatorState playingState;
-        [SerializeField]
         public static int controlStateHash { get; set; }
 
         // animator/animation settings


### PR DESCRIPTION
Error in Unity 6000.3.0f1

Library/PackageCache/com.soupday.cc3_unity_tools@2a7288afe99f/Editor/AnimPlayerGUI.cs(207,10): error CS0592: Attribute 'SerializeField' is not valid on this declaration type. It is only valid on 'field' declarations.

Unity discusses the change here: https://docs.unity3d.com/Manual/UpgradeGuideUnity63.html