### PR TITLE
Avoid IndexOutOfRangeException during mesh extraction and submesh removal

### DIFF
--- a/Editor/MeshUtil.cs
+++ b/Editor/MeshUtil.cs
@@ -793,14 +793,14 @@ namespace Reallusion.Import
             Color[] srcColors = srcMesh.colors;
             BoneWeight[] srcBoneWeights = srcMesh.boneWeights;
             Vector4[] srcTangents = srcMesh.tangents;
-            int[] srcTriangles = srcMesh.triangles;
+            int[] srcTriangles = srcMesh.GetTriangles(index);
 
             // first determine which vertices are used in the faces of the indexed submesh and remap their indices to the new mesh.
             int maxVerts = srcMesh.vertexCount;
             int[] remapping = new int[maxVerts];
             for (int i = 0; i < maxVerts; i++) remapping[i] = -1;
             int pointer = 0;
-            for (int tIndex = extractMeshDesc.indexStart; tIndex < extractMeshDesc.indexStart + extractMeshDesc.indexCount; tIndex++)
+            for (int tIndex = 0; tIndex < srcTriangles.Length; tIndex++)
             {
                 int vertIndex = srcTriangles[tIndex];
                 if (remapping[vertIndex] == -1) remapping[vertIndex] = pointer++;
@@ -874,9 +874,9 @@ namespace Reallusion.Import
             newMesh.bounds = srcMesh.bounds;
             newMesh.subMeshCount = 1;
             // finally copy and remap the triangle data last
-            int[] triangles = new int[extractMeshDesc.indexCount];
+            int[] triangles = new int[srcTriangles.Length];
             pointer = 0;
-            for (int tIndex = extractMeshDesc.indexStart; tIndex < extractMeshDesc.indexStart + extractMeshDesc.indexCount; tIndex++)
+            for (int tIndex = 0; tIndex < srcTriangles.Length; tIndex++)
             {
                 int vertIndex = srcTriangles[tIndex];
                 int remappedIndex = remapping[vertIndex];
@@ -930,7 +930,7 @@ namespace Reallusion.Import
             SubMeshDescriptor newMeshDesc = extractMeshDesc;
             newMeshDesc.firstVertex = 0;
             newMeshDesc.indexStart = 0;
-            newMeshDesc.indexCount = extractMeshDesc.indexCount;
+            newMeshDesc.indexCount = triangles.Length;
             newMeshDesc.vertexCount = numNewVerts;
             newMesh.SetSubMesh(0, newMeshDesc);
 
@@ -955,9 +955,10 @@ namespace Reallusion.Import
             Color[] srcColors = srcMesh.colors;
             BoneWeight[] srcBoneWeights = srcMesh.boneWeights;
             Vector4[] srcTangents = srcMesh.tangents;
-            int[] srcTriangles = srcMesh.triangles;
+            int[][] subMeshTriangles = new int[srcMesh.subMeshCount][];
+            for (int s = 0; s < srcMesh.subMeshCount; s++) subMeshTriangles[s] = srcMesh.GetTriangles(s);
 
-            // first determine which vertices are used in the faces of *ALL SUBMESHES EXCEPT* the indexed submesh
+            // first determine which vertices are used in the faces of *ALL SUBMESHES EXCEPT* the indexed submesh 
             // and remap their indices to the new mesh.
             int maxVerts = srcMesh.vertexCount;
             int[] remapping = new int[maxVerts];
@@ -968,11 +969,11 @@ namespace Reallusion.Import
             {
                 if (!indices.Contains(s))
                 {
-                    SubMeshDescriptor meshDesc = srcMesh.GetSubMesh(s);
-                    numNewTriangles += meshDesc.indexCount;
-                    for (int tIndex = meshDesc.indexStart; tIndex < meshDesc.indexStart + meshDesc.indexCount; tIndex++)
+                    int[] smTriangles = subMeshTriangles[s];
+                    numNewTriangles += smTriangles.Length;
+                    for (int tIndex = 0; tIndex < smTriangles.Length; tIndex++)
                     {
-                        int vertIndex = srcTriangles[tIndex];
+                        int vertIndex = smTriangles[tIndex];
                         if (remapping[vertIndex] == -1) remapping[vertIndex] = pointer++;
                     }
                 }
@@ -1046,10 +1047,10 @@ namespace Reallusion.Import
             {
                 if (!indices.Contains(s))
                 {
-                    SubMeshDescriptor meshDesc = srcMesh.GetSubMesh(s);
-                    for (int tIndex = meshDesc.indexStart; tIndex < meshDesc.indexStart + meshDesc.indexCount; tIndex++)
-                    {
-                        int vertIndex = srcTriangles[tIndex];
+                    int[] smTriangles = subMeshTriangles[s];
+                    for (int tIndex = 0; tIndex < smTriangles.Length; tIndex++)
+                    {                    
+                        int vertIndex = smTriangles[tIndex];
                         int remappedIndex = remapping[vertIndex];
                         if (remappedIndex >= 0)
                             triangles[pointer++] = remappedIndex;
@@ -1108,10 +1109,10 @@ namespace Reallusion.Import
                     SubMeshDescriptor newMeshDesc = meshDesc;
                     newMeshDesc.firstVertex = remapping[meshDesc.firstVertex];
                     newMeshDesc.indexStart = indexStart;
-                    newMeshDesc.indexCount = meshDesc.indexCount;
-                    newMeshDesc.vertexCount = meshDesc.vertexCount;
+                    newMeshDesc.indexCount = subMeshTriangles[s].Length;
+                    newMeshDesc.vertexCount = meshDesc.vertexCount;                    
                     newMesh.SetSubMesh(pointer++, newMeshDesc);
-                    indexStart += meshDesc.indexCount;
+                    indexStart += subMeshTriangles[s].Length;
                 }
             }
 


### PR DESCRIPTION
MeshUtil.cs: When working with submeshes, use the actual number of triangles they report instead of relying on the mesh description's claimed number, which can be inaccurate and result in a crash.

### The Problem
For unknown reasons, submesh descriptors can sometimes report an incorrect number of indices. Attempting to iterate using these numbers results in an out of range exception. See detailed example below.

### The Solution
Instead of getting all the mesh's triangles and iterating through a subset inferred from the submesh descriptor, get the triangles for that specific submesh and iterate through them as normal. This ensures the index is always in range.

### Example

Crash:
<img width="1129" height="126" alt="Example Subindex Error" src="https://github.com/user-attachments/assets/ec0f7f95-5d42-4619-902e-930222bf02ee" />

In this case, it attempted to iterate up to index 190,935 of an array with only 92,202 objects because of numbers the mesh description reported:
<img width="415" height="455" alt="Diagnostic Logs" src="https://github.com/user-attachments/assets/465a0047-8ca5-41c5-9851-68b654a23b49" />
